### PR TITLE
Update GitHub actions to use major version

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
       - name: Setup Node environment
-        uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
       - name: Setup Node environment
-        uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
       - name: Setup Node environment
-        uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -153,7 +153,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
       - name: Setup Node environment
-        uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -199,7 +199,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
       - name: Setup Node environment
-        uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,7 +19,7 @@ jobs:
       node-modules: node-modules-${{ steps.node-modules.outputs.hash }}-v1
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - id: build
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - name: Setup Node environment
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - name: Setup Node environment
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - name: Setup Node environment
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - name: Setup Node environment

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Get cached dependencies
         id: cache-node-modules
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -60,7 +60,7 @@ jobs:
 
       - name: Get cached build
         id: cached-build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -90,7 +90,7 @@ jobs:
           node-version: '16'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -121,7 +121,7 @@ jobs:
           node-version: '16'
 
       - name: Get cached build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -158,7 +158,7 @@ jobs:
           node-version: '16'
 
       - name: Get cached build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -174,7 +174,7 @@ jobs:
           export_default_credentials: true
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -204,7 +204,7 @@ jobs:
           node-version: '16'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - id: build
         run: echo "::set-output name=hash::${{ hashFiles('bin/**', 'content/**', 'firebase/**', 'functions/src/**', 'src/**', 'static/**', '**/package.json', '**/yarn.lock') }}"
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Node environment
         uses: actions/setup-node@v3
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Node environment
         uses: actions/setup-node@v3
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Node environment
         uses: actions/setup-node@v3
@@ -150,7 +150,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Node environment
         uses: actions/setup-node@v3
@@ -196,7 +196,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Node environment
         uses: actions/setup-node@v3

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
       - name: Setup Node environment
-        uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
       - name: Setup Node environment
-        uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
       - name: Setup Node environment
-        uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -171,7 +171,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
       - name: Setup Node environment
-        uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -213,7 +213,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
       - name: Setup Node environment
-        uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -43,7 +43,7 @@ jobs:
           node-version: '16'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         id: cache-node-modules
         with:
           path: |
@@ -57,7 +57,7 @@ jobs:
 
       - name: Get cached build
         id: cached-build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -66,7 +66,7 @@ jobs:
           key: ${{ needs.cache-keys.outputs.build }}
 
       - name: Get .cache cache
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             .cache
@@ -93,7 +93,7 @@ jobs:
           node-version: '16'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -121,7 +121,7 @@ jobs:
           node-version: '16'
 
       - name: Get cached build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -176,7 +176,7 @@ jobs:
           node-version: '16'
 
       - name: Get cached build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -193,7 +193,7 @@ jobs:
 
       # Dependencies are needed here to run `yarn firbase` command
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -218,7 +218,7 @@ jobs:
           node-version: '16'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - id: build
         run: echo "::set-output name=hash::${{ hashFiles('bin/**', 'content/**', 'firebase/**', 'functions/src/**', 'src/**', 'static/**', '**/package.json', '**/yarn.lock') }}"
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Node environment
         uses: actions/setup-node@v3
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Node environment
         uses: actions/setup-node@v3
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Node environment
         uses: actions/setup-node@v3
@@ -168,7 +168,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Node environment
         uses: actions/setup-node@v3
@@ -210,7 +210,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Node environment
         uses: actions/setup-node@v3

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -19,7 +19,7 @@ jobs:
       node-modules: node-modules-${{ steps.node-modules.outputs.hash }}-v1
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - id: build
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - name: Setup Node environment
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - name: Setup Node environment
@@ -112,7 +112,7 @@ jobs:
       hosting-url: ${{ steps.deploy-preview-channel.outputs.details_url }}
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - name: Setup Node environment
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - name: Setup Node environment
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - name: Setup Node environment


### PR DESCRIPTION
- Use v3 of actions/setup-node
- Use v2 of actions/cache
- Use v3 of actions/checkout
- s/Checkout/Check Out/
