### PR TITLE
Fix Support site links in the footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -27,9 +27,9 @@
       </div>
       <div class="footer__group footer__group__support">
         <h3 class="footer__heading">Support</h3>
-        <a class="footer__link" href="">Knowledge Base</a>
-        <a class="footer__link" href="/hc/en-us/categories/1260801482329-minFraud-Web-Services">minFraud</a>
-        <a class="footer__link" href="/hc/en-us/categories/1260801446650-GeoIP2-and-GeoLite2">GeoIP</a>
+        <a class="footer__link" href="https://support.maxmind.com/">Knowledge Base</a>
+        <a class="footer__link" href="https://support.maxmind.com/hc/en-us/categories/1260801482329-minFraud-Web-Services">minFraud</a>
+        <a class="footer__link" href="https://support.maxmind.com/hc/en-us/categories/1260801446650-GeoIP2-and-GeoLite2">GeoIP</a>
         <a class="footer__link footer__status" href="https://status.maxmind.com/">
           <span class="footer__status-icon">
             {{ readFile "assets/icon-status-operational.svg" | safeHTML }}


### PR DESCRIPTION
The top three links in the Support section of the blog-site footer were formatted as if the footer is served from the same subdomain as the Knowledge Base.