### PR TITLE
Dependabot/npm and yarn/typescript eslint/parser 6.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-security": "^1.7.1",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
-        "eslint-plugin-typescript-sort-keys": "^2.3.0",
+        "eslint-plugin-typescript-sort-keys": "^3.0.0",
         "husky": "^8.0.3",
         "lint-staged": "^14.0.1",
         "markdownlint-cli": "^0.35.0",
@@ -3190,9 +3190,9 @@
       }
     },
     "node_modules/eslint-plugin-typescript-sort-keys": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-2.3.0.tgz",
-      "integrity": "sha512-3LAcYulo5gNYiPWee+TksITfvWeBuBjGgcSLTacPESFVKEoy8laOQuZvJlSCwTBHT2SCGIxr3bJ56zuux+3MCQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-3.0.0.tgz",
+      "integrity": "sha512-bMmI4prYlf3l/1O8j8Nsz11m+XfKEHRFk9aJqP91L4Hgy7I38lnitnYElDmPQaznE1oFlGgBcnkEizNT2NLylQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^5.0.0",
@@ -3200,11 +3200,11 @@
         "natural-compare-lite": "^1.4.0"
       },
       "engines": {
-        "node": "12 || >= 13.9"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^1 || ^2 || ^3 || ^4 || ^5",
-        "eslint": "^5 || ^6 || ^7 || ^8",
+        "@typescript-eslint/parser": "^6",
+        "eslint": "^7 || ^8",
         "typescript": "^3 || ^4 || ^5"
       }
     },
@@ -12313,9 +12313,9 @@
       }
     },
     "eslint-plugin-typescript-sort-keys": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-2.3.0.tgz",
-      "integrity": "sha512-3LAcYulo5gNYiPWee+TksITfvWeBuBjGgcSLTacPESFVKEoy8laOQuZvJlSCwTBHT2SCGIxr3bJ56zuux+3MCQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-3.0.0.tgz",
+      "integrity": "sha512-bMmI4prYlf3l/1O8j8Nsz11m+XfKEHRFk9aJqP91L4Hgy7I38lnitnYElDmPQaznE1oFlGgBcnkEizNT2NLylQ==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint-plugin-security": "^1.7.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-sort-keys-fix": "^1.1.2",
-    "eslint-plugin-typescript-sort-keys": "^2.3.0",
+    "eslint-plugin-typescript-sort-keys": "^3.0.0",
     "husky": "^8.0.3",
     "lint-staged": "^14.0.1",
     "markdownlint-cli": "^0.35.0",


### PR DESCRIPTION
This is a breaking change. See https://github.com/infctr/eslint-plugin-typescript-sort-keys/releases/tag/v3.0.0