### PR TITLE
blog-site fix:content is fixed

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -53,7 +53,7 @@ module.exports = {
   settings: {
     fences: true,
     incrementListMarker: false,
-    listItemIndent: 1,
+    listItemIndent: 'one',
     ruleRepetition: 3,
   },
 };

--- a/content/2024/06/maxmind-appoints-seasoned-data-science-leader-rupert-young-as-chief-product-officer.md
+++ b/content/2024/06/maxmind-appoints-seasoned-data-science-leader-rupert-young-as-chief-product-officer.md
@@ -28,9 +28,9 @@ Science degree in Computer Science and Electrical Engineering.
 
 A technology and business-savvy leader with decades of industry experience,
 Rupert has held key roles in product, engineering, and business development at
-companies such as Neustar, AT&T, and most recently F5, where he was in charge of
-fraud and risk products. Over the last 15 years, Rupert has also worked closely
-with data science teams to uncover insights about—and for—customers.
+companies such as Neustar, AT\&T, and most recently F5, where he was in charge
+of fraud and risk products. Over the last 15 years, Rupert has also worked
+closely with data science teams to uncover insights about—and for—customers.
 
 As MaxMind’s Chief Product Officer, Rupert will be undertaking a number of
 strategic initiatives to accelerate product innovation.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "name": "blog-site",
   "scripts": {
     "fix": "run-p fix:*",
-    "fix:content": "remark . --output --ext md --quiet && prettier --write '**/*.md' --embedded-language-formatting off --loglevel silent",
+    "fix:content": "remark . --output --ext md --quiet && prettier --write '**/*.md' --embedded-language-formatting off --log-level silent",
     "fix:scripts": "npm run lint:scripts --fix",
     "fix:styles": "npm run lint:styles --fix",
     "lint": "run-p lint:*",


### PR DESCRIPTION
The blog-site command `npm run fix:content` does not currently work. It throws an error due to an invalid config options. The allowable config options have likely changed with a recent update.

Fix whatever is causing this to fail

## AC
- `fix:content` works again