### PR TITLE
Revert "build(deps-dev): bump the minor-and-patch group across 1 directory with 5 updates"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "devDependencies": {
         "@eslint/compat": "^1.3.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "^9.35.0",
-        "cspell": "^9.2.1",
-        "eslint": "^9.35.0",
+        "@eslint/js": "^9.33.0",
+        "cspell": "^9.2.0",
+        "eslint": "^9.33.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-security": "^3.0.1",
@@ -22,13 +22,13 @@
         "markdownlint-cli": "^0.45.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.6.2",
-        "stylelint": "^16.24.0",
+        "stylelint": "^16.23.1",
         "stylelint-config-recommended": "^17.0.0",
         "stylelint-config-sass-guidelines": "^12.1.0",
         "stylelint-no-unsupported-browser-features": "^8.0.4",
         "stylelint-order": "^7.0.0",
         "typescript": "^5.9.2",
-        "typescript-eslint": "^8.42.0"
+        "typescript-eslint": "^8.39.1"
       },
       "engines": {
         "node": ">=22",
@@ -57,30 +57,30 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.2.1.tgz",
-      "integrity": "sha512-85gHoZh3rgZ/EqrHIr1/I4OLO53fWNp6JZCqCdgaT7e3sMDaOOG6HoSxCvOnVspXNIf/1ZbfTCDMx9x79Xq0AQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.2.0.tgz",
+      "integrity": "sha512-e4qb78SQWqHkRw47W8qFJ3RPijhSLkADF+T0oH8xl3r/golq1RGp2/KrWOqGRRofUSTiIKYqaMX7mbAyFnOxyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspell/dict-ada": "^4.1.1",
         "@cspell/dict-al": "^1.1.1",
-        "@cspell/dict-aws": "^4.0.15",
+        "@cspell/dict-aws": "^4.0.12",
         "@cspell/dict-bash": "^4.2.1",
-        "@cspell/dict-companies": "^3.2.5",
-        "@cspell/dict-cpp": "^6.0.12",
+        "@cspell/dict-companies": "^3.2.2",
+        "@cspell/dict-cpp": "^6.0.9",
         "@cspell/dict-cryptocurrencies": "^5.0.5",
         "@cspell/dict-csharp": "^4.0.7",
         "@cspell/dict-css": "^4.0.18",
         "@cspell/dict-dart": "^2.3.1",
         "@cspell/dict-data-science": "^2.0.9",
         "@cspell/dict-django": "^4.1.5",
-        "@cspell/dict-docker": "^1.1.16",
+        "@cspell/dict-docker": "^1.1.15",
         "@cspell/dict-dotnet": "^5.0.10",
         "@cspell/dict-elixir": "^4.0.8",
-        "@cspell/dict-en_us": "^4.4.18",
-        "@cspell/dict-en-common-misspellings": "^2.1.5",
-        "@cspell/dict-en-gb-mit": "^3.1.8",
+        "@cspell/dict-en_us": "^4.4.15",
+        "@cspell/dict-en-common-misspellings": "^2.1.3",
+        "@cspell/dict-en-gb-mit": "^3.1.5",
         "@cspell/dict-filetypes": "^3.0.13",
         "@cspell/dict-flutter": "^1.1.1",
         "@cspell/dict-fonts": "^4.0.5",
@@ -104,17 +104,17 @@
         "@cspell/dict-markdown": "^2.0.12",
         "@cspell/dict-monkeyc": "^1.0.11",
         "@cspell/dict-node": "^5.0.8",
-        "@cspell/dict-npm": "^5.2.15",
+        "@cspell/dict-npm": "^5.2.12",
         "@cspell/dict-php": "^4.0.15",
         "@cspell/dict-powershell": "^5.0.15",
-        "@cspell/dict-public-licenses": "^2.0.15",
+        "@cspell/dict-public-licenses": "^2.0.14",
         "@cspell/dict-python": "^4.2.19",
         "@cspell/dict-r": "^2.1.1",
         "@cspell/dict-ruby": "^5.0.9",
         "@cspell/dict-rust": "^4.0.12",
         "@cspell/dict-scala": "^5.0.8",
         "@cspell/dict-shell": "^1.1.1",
-        "@cspell/dict-software-terms": "^5.1.7",
+        "@cspell/dict-software-terms": "^5.1.4",
         "@cspell/dict-sql": "^2.2.1",
         "@cspell/dict-svelte": "^1.0.7",
         "@cspell/dict-swift": "^2.0.6",
@@ -127,22 +127,22 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.2.1.tgz",
-      "integrity": "sha512-LiiIWzLP9h2etKn0ap6g2+HrgOGcFEF/hp5D8ytmSL5sMxDcV13RrmJCEMTh1axGyW0SjQEFjPnYzNpCL1JjGA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.2.0.tgz",
+      "integrity": "sha512-qHdkW8eyknCSDEsqCG8OHBMal03LQf21H2LVWhtwszEQ4BQRKcWctc+VIgkO69F/jLaN2wi/yhhMufXWHAEzIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.2.1"
+        "@cspell/cspell-types": "9.2.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.2.1.tgz",
-      "integrity": "sha512-2N1H63If5cezLqKToY/YSXon4m4REg/CVTFZr040wlHRbbQMh5EF3c7tEC/ue3iKAQR4sm52ihfqo1n4X6kz+g==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.2.0.tgz",
+      "integrity": "sha512-RO3adcsr7Ek+4511nyEOWDhOYYU1ogRs1Mo5xx3kDIdcKAJzhFdGry35T2wqft4dPASLCXcemBrhoS+hdQ+z+Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.2.1.tgz",
-      "integrity": "sha512-fRPQ6GWU5eyh8LN1TZblc7t24TlGhJprdjJkfZ+HjQo+6ivdeBPT7pC7pew6vuMBQPS1oHBR36hE0ZnJqqkCeg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.2.0.tgz",
+      "integrity": "sha512-0Xvwq0iezfO71Alw+DjsGxacAzydqOAxdXnY4JknHuxt2l8GTSMjRwj65QAflv3PN6h1QoRZEeWdiKtusceWAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.2.1.tgz",
-      "integrity": "sha512-k4M6bqdvWbcGSbcfLD7Lf4coZVObsISDW+sm/VaWp9aZ7/uwiz1IuGUxL9WO4JIdr9CFEf7Ivmvd2txZpVOCIA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.2.0.tgz",
+      "integrity": "sha512-ZDvcOTFk3cCVW+OjlkljeP7aSuV8tIguVn+GMco1/A+961hsEP20hngK9zJtyfpXqyvJKtvCVlyzS+z8VRrZGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-9.2.1.tgz",
-      "integrity": "sha512-FQHgQYdTHkcpxT0u1ddLIg5Cc5ePVDcLg9+b5Wgaubmc5I0tLotgYj8c/mvStWuKsuZIs6sUopjJrE91wk6Onw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-9.2.0.tgz",
+      "integrity": "sha512-hL4ltFwiARpFxlfXt4GiTWQxIFyZp4wrlp7dozZbitYO6QlYc5fwQ8jBc5zFUqknuH4gx/sCMLNXhAv3enNGZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -197,9 +197,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-aws": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.15.tgz",
-      "integrity": "sha512-aPY7VVR5Os4rz36EaqXBAEy14wR4Rqv+leCJ2Ug/Gd0IglJpM30LalF3e2eJChnjje3vWoEC0Rz3+e5gpZG+Kg==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.14.tgz",
+      "integrity": "sha512-qLPR+OFmpzyUcuUYyCQFIURDDUGIlQsdGirPyvaIrXxs2giCKG97cAuFz5EleL3/Lo7uJAVDw0lt4Ka7wIRhjQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -214,16 +214,16 @@
       }
     },
     "node_modules/@cspell/dict-companies": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.5.tgz",
-      "integrity": "sha512-H51R0w7c6RwJJPqH7Gs65tzP6ouZsYDEHmmol6MIIk0kQaOIBuFP2B3vIxHLUr2EPRVFZsMW8Ni7NmVyaQlwsg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.3.tgz",
+      "integrity": "sha512-7ekwamRYeS7G3I3LEKM3t0WIyAytCbsx2I2h2z2eEvF+b3TmtJVcV7UI7BScLue3bep4sPB/b4CV3BUv3QfyzQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.12.tgz",
-      "integrity": "sha512-N4NsCTttVpMqQEYbf0VQwCj6np+pJESov0WieCN7R/0aByz4+MXEiDieWWisaiVi8LbKzs1mEj4ZTw5K/6O2UQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.9.tgz",
+      "integrity": "sha512-Xdq9MwGh0D5rsnbOqFW24NIClXXRhN11KJdySMibpcqYGeomxB2ODFBuhj1H7azO7kVGkGH0Okm4yQ2TRzBx0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -291,23 +291,23 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.19.tgz",
-      "integrity": "sha512-JYYgzhGqSGuIMNY1cTlmq3zrNpehrExMHqLmLnSM2jEGFeHydlL+KLBwBYxMy4e73w+p1+o/rmAiGsMj9g3MCw==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.16.tgz",
+      "integrity": "sha512-/R47sUbUmba2dG/0LZyE6P6gX/DRF1sCcYNQNWyPk/KeidQRNZG+FH9U0KRvX42/2ZzMge6ebXH3WAJ52w0Vqw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.6.tgz",
-      "integrity": "sha512-xV9yryOqZizbSqxRS7kSVRrxVEyWHUqwdY56IuT7eAWGyTCJNmitXzXa4p+AnEbhL+AB2WLynGVSbNoUC3ceFA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.3.tgz",
+      "integrity": "sha512-v1I97Hr1OrK+mwHsVzbY4vsPxx6mA5quhxzanF6XuRofz00wH4HPz8Q3llzRHxka5Wl/59gyan04UkUrvP4gdA==",
       "dev": true,
       "license": "CC BY-SA 4.0"
     },
     "node_modules/@cspell/dict-en-gb-mit": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.9.tgz",
-      "integrity": "sha512-1lSnphnHTOxnpNLpPLg1XXv8df3hs4oL0LJ6dkQ0IqNROl8Jzl6PD55BDTlKy4YOAA76dJlePB0wyrxB+VVKbg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.6.tgz",
+      "integrity": "sha512-3JJGxuPhDK5rMDYPzJYAdjjsBddEyV54rXfUQpOCl7c7weMhNDWfC2q4h3cKNDj7Isud1q2RM+DlSxQWf40OTw==",
       "dev": true,
       "license": "MIT"
     },
@@ -479,9 +479,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.2.17",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.17.tgz",
-      "integrity": "sha512-0yp7lBXtN3CtxBrpvTu/yAuPdOHR2ucKzPxdppc3VKO068waZNpKikn1NZCzBS3dIAFGVITzUPtuTXxt9cxnSg==",
+      "version": "5.2.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.13.tgz",
+      "integrity": "sha512-yE7DfpiQjDFW6TLr5/fsSj4BlUy1A8lsuz2LQQHv4lQAAkZ4RsePYFL9DkRRfEtxn8CZYetUnU74/jQbfsnyrA==",
       "dev": true,
       "license": "MIT"
     },
@@ -500,9 +500,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-public-licenses": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.15.tgz",
-      "integrity": "sha512-cJEOs901H13Pfy0fl4dCD1U+xpWIMaEPq8MeYU83FfDZvellAuSo4GqWCripfIqlhns/L6+UZEIJSOZnjgy7Wg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.14.tgz",
+      "integrity": "sha512-8NhNzQWALF6+NlLeKZKilSHbeW9MWeiD+NcrjehMAcovKFbsn8smmQG/bVxw+Ymtd6WEgNpLgswAqNsbSQQ4og==",
       "dev": true,
       "license": "MIT"
     },
@@ -552,9 +552,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.1.8.tgz",
-      "integrity": "sha512-iwCHLP11OmVHEX2MzE8EPxpPw7BelvldxWe5cJ3xXIDL8TjF2dBTs2noGcrqnZi15SLYIlO8897BIOa33WHHZA==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.1.5.tgz",
+      "integrity": "sha512-MX5beBP3pLmIM0mjqfrHbie3EEfyLWZ8ZqW56jcLuRlLoDcfC0FZsr66NCARgCgEwsWiidHFe87+7fFsnwqY6A==",
       "dev": true,
       "license": "MIT"
     },
@@ -601,23 +601,23 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.2.1.tgz",
-      "integrity": "sha512-izYQbk7ck0ffNA1gf7Gi3PkUEjj+crbYeyNK1hxHx5A+GuR416ozs0aEyp995KI2v9HZlXscOj3SC3wrWzHZeA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.2.0.tgz",
+      "integrity": "sha512-2/k4LR8CQqbgIPQGELbCdt9xgg9+aQ7pMwOtllKvnFYBtwNiwqcZjlzAam2gtvD5DghKX2qrcSHG5A7YP5cX9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.2.1",
-        "import-meta-resolve": "^4.2.0"
+        "@cspell/url": "9.2.0",
+        "import-meta-resolve": "^4.1.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.2.1.tgz",
-      "integrity": "sha512-Dy1y1pQ+7hi2gPs+jERczVkACtYbUHcLodXDrzpipoxgOtVxMcyZuo+84WYHImfu0gtM0wU2uLObaVgMSTnytw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.2.0.tgz",
+      "integrity": "sha512-6wmCa3ZyI647H7F4w6kb9PCJ703JKSgFTB8EERTdIoGySbgVp5+qMIIoZ//wELukdjgcufcFZ5pBrhRDRsemRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.2.1.tgz",
-      "integrity": "sha512-1HsQWZexvJSjDocVnbeAWjjgqWE/0op/txxzDPvDqI2sE6pY0oO4Cinj2I8z+IP+m6/E6yjPxdb23ydbQbPpJQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.2.0.tgz",
+      "integrity": "sha512-5mpIMiIOCu4cBqy1oCTXISgJuOCQ6R/e38AkvnYWfmMIx7fCdx8n+mF52wX9m61Ng28Sq8VL253xybsWcCxHug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -635,9 +635,9 @@
       }
     },
     "node_modules/@cspell/url": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.2.1.tgz",
-      "integrity": "sha512-9EHCoGKtisPNsEdBQ28tKxKeBmiVS3D4j+AN8Yjr+Dmtu+YACKGWiMOddNZG2VejQNIdFx7FwzU00BGX68ELhA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.2.0.tgz",
+      "integrity": "sha512-plB0wwdAESqBl4xDAT2db2/K1FZHJXfYlJTiV6pkn0XffTGyg4UGLaSCm15NzUoPxdSmzqj5jQb7y+mB9kFK8g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -742,9 +742,7 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.7.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -869,9 +867,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
-      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "version": "9.33.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
+      "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1122,17 +1120,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.42.0.tgz",
-      "integrity": "sha512-Aq2dPqsQkxHOLfb2OPv43RnIvfj05nw8v/6n3B2NABIPpHnjQnaLo9QGMTvml+tv4korl/Cjfrb/BYhoL8UUTQ==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
+      "integrity": "sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.42.0",
-        "@typescript-eslint/type-utils": "8.42.0",
-        "@typescript-eslint/utils": "8.42.0",
-        "@typescript-eslint/visitor-keys": "8.42.0",
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/type-utils": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1146,7 +1144,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.42.0",
+        "@typescript-eslint/parser": "^8.39.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -1162,16 +1160,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.42.0.tgz",
-      "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.1.tgz",
+      "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.42.0",
-        "@typescript-eslint/types": "8.42.0",
-        "@typescript-eslint/typescript-estree": "8.42.0",
-        "@typescript-eslint/visitor-keys": "8.42.0",
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1187,14 +1185,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.42.0.tgz",
-      "integrity": "sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.1.tgz",
+      "integrity": "sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.42.0",
-        "@typescript-eslint/types": "^8.42.0",
+        "@typescript-eslint/tsconfig-utils": "^8.39.1",
+        "@typescript-eslint/types": "^8.39.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1209,14 +1207,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.42.0.tgz",
-      "integrity": "sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.1.tgz",
+      "integrity": "sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.42.0",
-        "@typescript-eslint/visitor-keys": "8.42.0"
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1227,9 +1225,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.42.0.tgz",
-      "integrity": "sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.1.tgz",
+      "integrity": "sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1244,15 +1242,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.42.0.tgz",
-      "integrity": "sha512-9KChw92sbPTYVFw3JLRH1ockhyR3zqqn9lQXol3/YbI6jVxzWoGcT3AsAW0mu1MY0gYtsXnUGV/AKpkAj5tVlQ==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.1.tgz",
+      "integrity": "sha512-gu9/ahyatyAdQbKeHnhT4R+y3YLtqqHyvkfDxaBYk97EcbfChSJXyaJnIL3ygUv7OuZatePHmQvuH5ru0lnVeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.42.0",
-        "@typescript-eslint/typescript-estree": "8.42.0",
-        "@typescript-eslint/utils": "8.42.0",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1269,9 +1267,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.42.0.tgz",
-      "integrity": "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
+      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1283,16 +1281,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.42.0.tgz",
-      "integrity": "sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.1.tgz",
+      "integrity": "sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.42.0",
-        "@typescript-eslint/tsconfig-utils": "8.42.0",
-        "@typescript-eslint/types": "8.42.0",
-        "@typescript-eslint/visitor-keys": "8.42.0",
+        "@typescript-eslint/project-service": "8.39.1",
+        "@typescript-eslint/tsconfig-utils": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1338,16 +1336,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.42.0.tgz",
-      "integrity": "sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.1.tgz",
+      "integrity": "sha512-VF5tZ2XnUSTuiqZFXCZfZs1cgkdd3O/sSYmdo2EpSyDlC86UM/8YytTmKnehOW3TGAlivqTDT6bS87B/GQ/jyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.42.0",
-        "@typescript-eslint/types": "8.42.0",
-        "@typescript-eslint/typescript-estree": "8.42.0"
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1362,13 +1360,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.42.0.tgz",
-      "integrity": "sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
+      "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/types": "8.39.1",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -1597,14 +1595,14 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.4.tgz",
-      "integrity": "sha512-Gd7ccIUkZ9TE2odLQVS+PDjIvQCdJKUlLdJRVvZu0aipj07Qfx+XIej7hhDrKGGoIxV5m5fT/kOJNJPQhQneRg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.3.tgz",
+      "integrity": "sha512-M6p10iJ/VT0wT7TLIGUnm958oVrU2cUK8pQAVU21Zu7h8rbk/PeRtRWrvHJBql97Bhzk3g1N6+2VKC+Rjxna9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.11.0",
-        "keyv": "^5.5.0"
+        "hookified": "^1.10.0",
+        "keyv": "^5.4.0"
       }
     },
     "node_modules/cacheable/node_modules/keyv": {
@@ -1689,9 +1687,7 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.1.tgz",
-      "integrity": "sha512-5b8G5vAwZY6ae5Vrp8HcIip49h0n88ASWNfK02h9aUjdPdhac481t5Ry7wXamd0gUvyK1KvS/dePAwAkEms4pw==",
+      "version": "5.4.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1978,26 +1974,26 @@
       }
     },
     "node_modules/cspell": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-9.2.1.tgz",
-      "integrity": "sha512-PoKGKE9Tl87Sn/jwO4jvH7nTqe5Xrsz2DeJT5CkulY7SoL2fmsAqfbImQOFS2S0s36qD98t6VO+Ig2elEEcHew==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-9.2.0.tgz",
+      "integrity": "sha512-AKzaFMem2jRcGpAY2spKP0z15jpZeX1WTDNHCDsB8/YvnhnOfWXc0S5AF+4sfU1cQgHWYGFOolMuTri0ZQdV+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "9.2.1",
-        "@cspell/cspell-pipe": "9.2.1",
-        "@cspell/cspell-types": "9.2.1",
-        "@cspell/dynamic-import": "9.2.1",
-        "@cspell/url": "9.2.1",
-        "chalk": "^5.6.0",
+        "@cspell/cspell-json-reporter": "9.2.0",
+        "@cspell/cspell-pipe": "9.2.0",
+        "@cspell/cspell-types": "9.2.0",
+        "@cspell/dynamic-import": "9.2.0",
+        "@cspell/url": "9.2.0",
+        "chalk": "^5.4.1",
         "chalk-template": "^1.1.0",
         "commander": "^14.0.0",
-        "cspell-config-lib": "9.2.1",
-        "cspell-dictionary": "9.2.1",
-        "cspell-gitignore": "9.2.1",
-        "cspell-glob": "9.2.1",
-        "cspell-io": "9.2.1",
-        "cspell-lib": "9.2.1",
+        "cspell-config-lib": "9.2.0",
+        "cspell-dictionary": "9.2.0",
+        "cspell-gitignore": "9.2.0",
+        "cspell-glob": "9.2.0",
+        "cspell-io": "9.2.0",
+        "cspell-lib": "9.2.0",
         "fast-json-stable-stringify": "^2.1.0",
         "flatted": "^3.3.3",
         "semver": "^7.7.2",
@@ -2015,25 +2011,25 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.2.1.tgz",
-      "integrity": "sha512-qqhaWW+0Ilc7493lXAlXjziCyeEmQbmPMc1XSJw2EWZmzb+hDvLdFGHoX18QU67yzBtu5hgQsJDEDZKvVDTsRA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.2.0.tgz",
+      "integrity": "sha512-Yc8+hT+uIWWCi6WMhOL6HDYbBCP2qig1tgKGThHVeOx6GviieV10TZ5kQ+P7ONgoqw2nmm7uXIC19dGYx3DblQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.2.1",
+        "@cspell/cspell-types": "9.2.0",
         "comment-json": "^4.2.5",
-        "smol-toml": "^1.4.2",
-        "yaml": "^2.8.1"
+        "smol-toml": "^1.4.1",
+        "yaml": "^2.8.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/cspell-config-lib/node_modules/smol-toml": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
-      "integrity": "sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.1.tgz",
+      "integrity": "sha512-CxdwHXyYTONGHThDbq5XdwbFsuY4wlClRGejfE2NtwUtiHYsP1QtNsHb/hnj31jKYSchztJsaA8pSQoVzkfCFg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -2044,15 +2040,15 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.2.1.tgz",
-      "integrity": "sha512-0hQVFySPsoJ0fONmDPwCWGSG6SGj4ERolWdx4t42fzg5zMs+VYGXpQW4BJneQ5Tfxy98Wx8kPhmh/9E8uYzLTw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.2.0.tgz",
+      "integrity": "sha512-lV4VtjsDtxu8LyCcb6DY7Br4e/Aw1xfR8QvjYhHaJ8t03xry9STey5Rkfp+lz+hlVevNcn3lfCaacGuXyD+lLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "9.2.1",
-        "@cspell/cspell-types": "9.2.1",
-        "cspell-trie-lib": "9.2.1",
+        "@cspell/cspell-pipe": "9.2.0",
+        "@cspell/cspell-types": "9.2.0",
+        "cspell-trie-lib": "9.2.0",
         "fast-equals": "^5.2.2"
       },
       "engines": {
@@ -2060,15 +2056,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.2.1.tgz",
-      "integrity": "sha512-WPnDh03gXZoSqVyXq4L7t9ljx6lTDvkiSRUudb125egEK5e9s04csrQpLI3Yxcnc1wQA2nzDr5rX9XQVvCHf7g==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.2.0.tgz",
+      "integrity": "sha512-gXDQZ7czTPwmEg1qtsUIjVEFm9IfgTO8rA02O8eYIveqjFixbSV3fIYOgoxZSZYxjt3O44m8+/zAFC1RE4CM/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.2.1",
-        "cspell-glob": "9.2.1",
-        "cspell-io": "9.2.1"
+        "@cspell/url": "9.2.0",
+        "cspell-glob": "9.2.0",
+        "cspell-io": "9.2.0"
       },
       "bin": {
         "cspell-gitignore": "bin.mjs"
@@ -2078,13 +2074,13 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.2.1.tgz",
-      "integrity": "sha512-CrT/6ld3rXhB36yWFjrx1SrMQzwDrGOLr+wYEnrWI719/LTYWWCiMFW7H+qhsJDTsR+ku8+OAmfRNBDXvh9mnQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.2.0.tgz",
+      "integrity": "sha512-viycZDyegzW2AKPFqvX5RveqTrB0sKgexlCu2A8z8eumpYYor5sD1NP05VDOqkAF4hDuiGqkHn6iNo0L1wNgLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.2.1",
+        "@cspell/url": "9.2.0",
         "picomatch": "^4.0.3"
       },
       "engines": {
@@ -2092,14 +2088,14 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.2.1.tgz",
-      "integrity": "sha512-10RGFG7ZTQPdwyW2vJyfmC1t8813y8QYRlVZ8jRHWzer9NV8QWrGnL83F+gTPXiKR/lqiW8WHmFlXR4/YMV+JQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.2.0.tgz",
+      "integrity": "sha512-qthAmWcNHpYAmufy7YWVg9xwrYANkVlI40bgC2uGd8EnKssm/qOPhqXXNS+kLf+q0NmJM5nMgRLhCC23xSp3JA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "9.2.1",
-        "@cspell/cspell-types": "9.2.1"
+        "@cspell/cspell-pipe": "9.2.0",
+        "@cspell/cspell-types": "9.2.0"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -2109,42 +2105,42 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.2.1.tgz",
-      "integrity": "sha512-v9uWXtRzB+RF/Mzg5qMzpb8/yt+1bwtTt2rZftkLDLrx5ybVvy6rhRQK05gFWHmWVtWEe0P/pIxaG2Vz92C8Ag==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.2.0.tgz",
+      "integrity": "sha512-oxKiqFLcz629FmOId8UpdDznpMvCgpuktg4nkD2G9pYpRh+fRLZpP4QtZPyvJqvpUIzFhIOznMeHjsiBYHOZUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "9.2.1",
-        "@cspell/url": "9.2.1"
+        "@cspell/cspell-service-bus": "9.2.0",
+        "@cspell/url": "9.2.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.2.1.tgz",
-      "integrity": "sha512-KeB6NHcO0g1knWa7sIuDippC3gian0rC48cvO0B0B0QwhOxNxWVp8cSmkycXjk4ijBZNa++IwFjeK/iEqMdahQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.2.0.tgz",
+      "integrity": "sha512-RnhDIsETw6Ex0UaK3PFoJ2FwWMWfJPtdpNpv1qgmJwoGD4CzwtIqPOLtZ24zqdCP8ZnNTF/lwV/9rZVqifYjsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "9.2.1",
-        "@cspell/cspell-pipe": "9.2.1",
-        "@cspell/cspell-resolver": "9.2.1",
-        "@cspell/cspell-types": "9.2.1",
-        "@cspell/dynamic-import": "9.2.1",
-        "@cspell/filetypes": "9.2.1",
-        "@cspell/strong-weak-map": "9.2.1",
-        "@cspell/url": "9.2.1",
+        "@cspell/cspell-bundled-dicts": "9.2.0",
+        "@cspell/cspell-pipe": "9.2.0",
+        "@cspell/cspell-resolver": "9.2.0",
+        "@cspell/cspell-types": "9.2.0",
+        "@cspell/dynamic-import": "9.2.0",
+        "@cspell/filetypes": "9.2.0",
+        "@cspell/strong-weak-map": "9.2.0",
+        "@cspell/url": "9.2.0",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.5",
-        "cspell-config-lib": "9.2.1",
-        "cspell-dictionary": "9.2.1",
-        "cspell-glob": "9.2.1",
-        "cspell-grammar": "9.2.1",
-        "cspell-io": "9.2.1",
-        "cspell-trie-lib": "9.2.1",
+        "cspell-config-lib": "9.2.0",
+        "cspell-dictionary": "9.2.0",
+        "cspell-glob": "9.2.0",
+        "cspell-grammar": "9.2.0",
+        "cspell-io": "9.2.0",
+        "cspell-trie-lib": "9.2.0",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.2.2",
         "gensequence": "^7.0.0",
@@ -2159,14 +2155,14 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.2.1.tgz",
-      "integrity": "sha512-qOtbL+/tUzGFHH0Uq2wi7sdB9iTy66QNx85P7DKeRdX9ZH53uQd7qC4nEk+/JPclx1EgXX26svxr0jTGISJhLw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.2.0.tgz",
+      "integrity": "sha512-6GHL1KvLQzcPBSNY6QWOabq8YwRJAnNKamA0O/tRKy+11Hy99ysD4xvfu3kKYPAcobp5ZykX4nudHxy8yrEvng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "9.2.1",
-        "@cspell/cspell-types": "9.2.1",
+        "@cspell/cspell-pipe": "9.2.0",
+        "@cspell/cspell-types": "9.2.0",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -2657,19 +2653,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
-      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+      "version": "9.33.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
+      "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.21.0",
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.35.0",
+        "@eslint/js": "9.33.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -3037,13 +3033,13 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
-      "integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.3.tgz",
+      "integrity": "sha512-D+w75Ub8T55yor7fPgN06rkCAUbAYw2vpxJmmjv/GDAcvCnv9g7IvHhIZoxzRZThrXPFI2maeY24pPbtyYU7Lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.13"
+        "flat-cache": "^6.1.12"
       }
     },
     "node_modules/fill-range": {
@@ -3073,15 +3069,15 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.13.tgz",
-      "integrity": "sha512-gmtS2PaUjSPa4zjObEIn4WWliKyZzYljgxODBfxugpK6q6HU9ClXzgCJ+nlcPKY9Bt090ypTOLIFWkV0jbKFjw==",
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.12.tgz",
+      "integrity": "sha512-U+HqqpZPPXP5d24bWuRzjGqVqUcw64k4nZAbruniDwdRg0H10tvN7H6ku1tjhA4rg5B9GS3siEvwO2qjJJ6f8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^1.10.4",
+        "cacheable": "^1.10.3",
         "flatted": "^3.3.3",
-        "hookified": "^1.11.0"
+        "hookified": "^1.10.0"
       }
     },
     "node_modules/flatted": {
@@ -3507,9 +3503,9 @@
       }
     },
     "node_modules/hookified": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.0.tgz",
-      "integrity": "sha512-hMr1Y9TCLshScrBbV2QxJ9BROddxZ12MX9KsCtuGGy/3SmmN5H1PllKerrVlSotur9dlE8hmUKAOSa3WDzsZmQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.11.0.tgz",
+      "integrity": "sha512-aDdIN3GyU5I6wextPplYdfmWCo+aLmjjVbntmX6HLD5RCi/xKsivYEBhnRD+d9224zFf008ZpLMPlWF0ZodYZw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3572,9 +3568,9 @@
       }
     },
     "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6348,9 +6344,9 @@
       "license": "ISC"
     },
     "node_modules/stylelint": {
-      "version": "16.24.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.24.0.tgz",
-      "integrity": "sha512-7ksgz3zJaSbTUGr/ujMXvLVKdDhLbGl3R/3arNudH7z88+XZZGNLMTepsY28WlnvEFcuOmUe7fg40Q3lfhOfSQ==",
+      "version": "16.23.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.23.1.tgz",
+      "integrity": "sha512-dNvDTsKV1U2YtiUDfe9d2gp902veFeo3ecCWdGlmLm2WFrAV0+L5LoOj/qHSBABQwMsZPJwfC4bf39mQm1S5zw==",
       "dev": true,
       "funding": [
         {
@@ -6377,7 +6373,7 @@
         "debug": "^4.4.1",
         "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^10.1.4",
+        "file-entry-cache": "^10.1.3",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
@@ -6815,16 +6811,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.42.0.tgz",
-      "integrity": "sha512-ozR/rQn+aQXQxh1YgbCzQWDFrsi9mcg+1PM3l/z5o1+20P7suOIaNg515bpr/OYt6FObz/NHcBstydDLHWeEKg==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.1.tgz",
+      "integrity": "sha512-GDUv6/NDYngUlNvwaHM1RamYftxf782IyEDbdj3SeaIHHv8fNQVRC++fITT7kUJV/5rIA/tkoRSSskt6osEfqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.42.0",
-        "@typescript-eslint/parser": "8.42.0",
-        "@typescript-eslint/typescript-estree": "8.42.0",
-        "@typescript-eslint/utils": "8.42.0"
+        "@typescript-eslint/eslint-plugin": "8.39.1",
+        "@typescript-eslint/parser": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7200,9 +7196,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "devDependencies": {
     "@eslint/compat": "^1.3.2",
     "@eslint/eslintrc": "^3.3.1",
-    "@eslint/js": "^9.35.0",
-    "cspell": "^9.2.1",
-    "eslint": "^9.35.0",
+    "@eslint/js": "^9.33.0",
+    "cspell": "^9.2.0",
+    "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-security": "^3.0.1",
@@ -18,13 +18,13 @@
     "markdownlint-cli": "^0.45.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.6.2",
-    "stylelint": "^16.24.0",
+    "stylelint": "^16.23.1",
     "stylelint-config-recommended": "^17.0.0",
     "stylelint-config-sass-guidelines": "^12.1.0",
     "stylelint-no-unsupported-browser-features": "^8.0.4",
     "stylelint-order": "^7.0.0",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.42.0"
+    "typescript-eslint": "^8.39.1"
   },
   "engines": {
     "node": ">=22",


### PR DESCRIPTION
Reverts maxmind/blog-site#1175 due to including chalk 5.6.1 which has been removed from npm due to malicious code. We should wait for a new dependabot PR to be created which included chalk 5.6.2+