### PR TITLE
Link to canonical git install page (STF-557)

### DIFF
--- a/content/2020/09/enriching-mmdb-files-with-your-own-data-using-go.md
+++ b/content/2020/09/enriching-mmdb-files-with-your-own-data-using-go.md
@@ -36,7 +36,7 @@ consult this example code showing
 
 ## Prerequisites
 
-- you must have [`git`](https://git-scm.com/downloads/) installed in order to
+- you must have [`git`](https://git-scm.com/install/) installed in order to
   clone the code and install the dependencies, and it must be in your `$PATH`
 - [Go 1.14](https://go.dev/dl/) or later must be installed, and `go` must be in
   your `$PATH`


### PR DESCRIPTION
The `git-scm.com/downloads/` link in the 2020 "Enriching MMDB files" post returns HTTP 200 but is a client-side redirect stub (meta-refresh / `rel=canonical`) pointing to `https://git-scm.com/install/`, so the link checker's `max_redirects = 0` doesn't surface it. Link the canonical install page directly (verified 200, no redirect).

Follow-up to the STF-557 link sweep, matching the same fix made in the geolite2-ws-blogpost and mmdb-from-go-blogpost repos (flagged by @horgh).

Part of STF-557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)