### PR TITLE
Restrict links workflow to contents: read

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
zizmor reports an `excessive-permissions` finding for the `linkChecker` job in `links.yml`: with no `permissions:` block it inherits the default broad token. The job only checks out the repo and runs a link checker, so this grants it the minimal `contents: read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to ensure proper access control for automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->