### PR TITLE
exclude wsj links from lychee

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -47,6 +47,7 @@ exclude = [
     'https://metacpan\.org/pod/MaxMind::DB::Writer::Tree#DATA-TYPES',
     'https://metacpan\.org/pod/MaxMind::DB::Writer::Tree#Insert-Order-Merging-and-Overwriting',
     '^https://s1\.goeshow\.com',                          # Site refuses connections
+    '^https://www\.wsj\.com/',                            # Blocks bots with 401
 ]
 
 # Exclude file paths from getting checked (treated as regular expressions)


### PR DESCRIPTION
wsj.com blocks bots with 401 responses so it's links appear broken to lychee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link-checking configuration to exclude Wall Street Journal links from automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->